### PR TITLE
Fix weekday shift for custom habits

### DIFF
--- a/client/src/components/habits/HabitCard.tsx
+++ b/client/src/components/habits/HabitCard.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { formatDate } from "@/lib/dates";
+import { formatDate, parseLocalDate } from "@/lib/dates";
 import { queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -43,8 +43,8 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
   // Find if habit is completed for the given date
   const habitLog = logs.find(log => {
     // Standardize date formats for comparison
-    const logDate = new Date(log.date).toISOString().split('T')[0];
-    const compareDate = new Date(date).toISOString().split('T')[0];
+    const logDate = parseLocalDate(log.date).toISOString().split('T')[0];
+    const compareDate = parseLocalDate(date).toISOString().split('T')[0];
     return log.habitId === habit.id && logDate === compareDate;
   });
   
@@ -67,8 +67,8 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
       // Create optimistic update
       const updatedHabitLogsList = [...(logs || [])];
       const existingLogIndex = updatedHabitLogsList.findIndex(log => {
-        const logDate = new Date(log.date).toISOString().split('T')[0];
-        const compareDate = new Date(date).toISOString().split('T')[0];
+        const logDate = parseLocalDate(log.date).toISOString().split('T')[0];
+        const compareDate = parseLocalDate(date).toISOString().split('T')[0];
         return log.habitId === habit.id && logDate === compareDate;
       });
       

--- a/client/src/components/habits/HabitList.tsx
+++ b/client/src/components/habits/HabitList.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Habit, Category, HabitLog } from "@shared/schema";
 import { HabitCard } from "./HabitCard";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getStreakCount, formatDate } from "@/lib/dates";
+import { getStreakCount, formatDate, parseLocalDate } from "@/lib/dates";
 
 interface HabitListProps {
   selectedCategory: string;
@@ -93,7 +93,7 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
     return true;
   };
 
-  const dateObj = new Date(date);
+  const dateObj = parseLocalDate(date);
   const activeHabits = filteredHabits.filter(habit => isHabitActiveOnDate(habit, dateObj));
 
   // Calculate streaks for each habit
@@ -102,7 +102,7 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
     
     const completedDates = (habitLogs as HabitLog[])
       .filter((log: HabitLog) => log.habitId === habitId && log.completed)
-      .map((log: HabitLog) => new Date(log.date));
+      .map((log: HabitLog) => parseLocalDate(log.date));
     
     return getStreakCount(completedDates);
   };
@@ -110,8 +110,8 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
   // Filter logs for the selected date
   const currentDateLogs = habitLogs 
     ? (habitLogs as HabitLog[]).filter((log: HabitLog) => {
-        const logDate = new Date(log.date).toISOString().split('T')[0]; 
-        const compareDate = new Date(date).toISOString().split('T')[0];
+        const logDate = parseLocalDate(log.date).toISOString().split('T')[0];
+        const compareDate = parseLocalDate(date).toISOString().split('T')[0];
         return logDate === compareDate;
       }) 
     : [];

--- a/client/src/components/stats/HabitCharts.tsx
+++ b/client/src/components/stats/HabitCharts.tsx
@@ -15,7 +15,7 @@ import {
 } from "recharts";
 import { Skeleton } from "@/components/ui/skeleton";
 import { eachDayOfInterval, format, subMonths, isEqual } from "date-fns";
-import { formatDate } from "@/lib/dates";
+import { formatDate, parseLocalDate } from "@/lib/dates";
 
 export function HabitCharts() {
   const { data: habits, isLoading: isLoadingHabits } = useQuery<Habit[]>({
@@ -110,10 +110,10 @@ export function HabitCharts() {
   });
   
   const monthlyTrendData = Object.entries(dateGroups).map(([dateStr, label]) => {
-    const date = new Date(dateStr);
+    const date = parseLocalDate(dateStr);
     
     const dayLogs = habitLogs.filter(log => {
-      const logDate = new Date(log.date);
+      const logDate = parseLocalDate(log.date);
       return isEqual(
         new Date(logDate.getFullYear(), logDate.getMonth(), logDate.getDate()),
         new Date(date.getFullYear(), date.getMonth(), date.getDate())

--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -8,7 +8,8 @@ import {
   formatDate,
   formatShortWeekday,
   formatDayNumber,
-  isToday
+  isToday,
+  parseLocalDate
 } from "@/lib/dates";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { format } from "date-fns";
@@ -55,7 +56,7 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
     if (!habitLogs) return 0;
     
     const formattedDate = formatDate(date);
-    const logsForDay = habitLogs.filter(log => formatDate(new Date(log.date)) === formattedDate);
+    const logsForDay = habitLogs.filter(log => formatDate(parseLocalDate(log.date)) === formattedDate);
     
     if (logsForDay.length === 0) return 0;
     

--- a/client/src/lib/dates.ts
+++ b/client/src/lib/dates.ts
@@ -16,6 +16,12 @@ export function formatDayNumber(date: Date): string {
   return format(date, "d");
 }
 
+// Parse a YYYY-MM-DD string as a local date (avoids timezone offsets)
+export function parseLocalDate(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
 export function getCurrentWeekDates(): { start: Date; end: Date; days: Date[] } {
   const today = new Date();
   const start = startOfWeek(today, { weekStartsOn: 1 }); // Start on Monday


### PR DESCRIPTION
## Summary
- ensure ISO date strings get parsed as local dates to avoid timezone shifts
- apply local date parsing for habit checks and stats

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6846ec874c1083278c17aed3b021965b