### PR TITLE
Add Hebrew date to weekly overview

### DIFF
--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -8,6 +8,7 @@ import {
   formatDate,
   formatShortWeekday,
   formatDayNumber,
+  formatHebrewDate,
   isToday,
   parseLocalDate
 } from "@/lib/dates";
@@ -137,12 +138,15 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
                   {formatDayNumber(day)}
                 </span>
               </button>
-              <div 
+              <div
                 className={`mt-2 w-8 h-1.5 rounded-full ${
                   isSelected ? 'bg-primary' : 'bg-primary/50'
                 }`}
                 style={{ opacity }}
               ></div>
+              <span className="text-[10px] text-gray-500 mt-1">
+                {formatHebrewDate(day)}
+              </span>
             </div>
           );
         })}

--- a/client/src/lib/dates.ts
+++ b/client/src/lib/dates.ts
@@ -1,4 +1,5 @@
 import { format, subDays, addDays, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay } from "date-fns";
+import { toJewishDate } from "jewish-date";
 
 export function formatDate(date: Date): string {
   return format(date, "yyyy-MM-dd");
@@ -14,6 +15,11 @@ export function formatShortWeekday(date: Date): string {
 
 export function formatDayNumber(date: Date): string {
   return format(date, "d");
+}
+
+export function formatHebrewDate(date: Date): string {
+  const { day, monthName } = toJewishDate(date);
+  return `${day} ${monthName}`;
 }
 
 // Parse a YYYY-MM-DD string as a local date (avoids timezone offsets)

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "express-session": "^1.18.1",
         "framer-motion": "^11.13.1",
         "input-otp": "^1.2.4",
+        "jewish-date": "^2.0.20",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
         "passport": "^0.7.0",
@@ -5622,6 +5623,12 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/gematriya": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gematriya/-/gematriya-2.0.0.tgz",
+      "integrity": "sha512-i+G3iGTn/vmojZkvS0dDPcw46tREqS10mztDOVoG6AACZzqp0eOpvIYaAOqZEiH4ee0Rkgt1Sf6jWM1GobJIeg==",
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5960,6 +5967,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jewish-date": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/jewish-date/-/jewish-date-2.0.20.tgz",
+      "integrity": "sha512-QY280ka/4c8t4tULb6qM103dAFZn4qrNEt3TJRaDo5y4nTA9EdlUgqjCJZI1Pa9pTc9+5VDXX+fhxP+SZKToKw==",
+      "license": "MIT",
+      "dependencies": {
+        "gematriya": "^2.0.0"
       }
     },
     "node_modules/jiti": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express-session": "^1.18.1",
     "framer-motion": "^11.13.1",
     "input-otp": "^1.2.4",
+    "jewish-date": "^2.0.20",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary
- install `jewish-date` for Hebrew date conversion
- expose `formatHebrewDate` helper
- show the Hebrew date below each day in the Weekly Overview calendar

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68472ab551888327a2f7d6537ae837e6