### PR TITLE
Support multi-state habit log statuses

### DIFF
--- a/client/src/components/ReminderChecker.tsx
+++ b/client/src/components/ReminderChecker.tsx
@@ -46,7 +46,7 @@ const ReminderChecker = ({ habits }: Props) => {
         const doneToday = habitLogs?.some(
           (log) =>
             log.habitId === habit.id &&
-            log.completed &&
+            log.status === "complete" &&
             log.date.startsWith(todayIso)
         );
 

--- a/client/src/components/habits/HabitList.tsx
+++ b/client/src/components/habits/HabitList.tsx
@@ -86,7 +86,7 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
     if (!habitLogs) return 0;
     
     const completedDates = (habitLogs as HabitLog[])
-      .filter((log: HabitLog) => log.habitId === habitId && log.completed)
+      .filter((log: HabitLog) => log.habitId === habitId && log.status === "complete")
       .map((log: HabitLog) => parseLocalDate(log.date));
     
     return getStreakCount(completedDates);

--- a/client/src/components/stats/CircularProgressDisplay.tsx
+++ b/client/src/components/stats/CircularProgressDisplay.tsx
@@ -78,7 +78,7 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
   const activeHabitIds = activeHabits.map(h => h.id);
   const totalHabits = activeHabits.length;
   const completedHabits = habitLogs.filter(
-    log => log.completed && activeHabitIds.includes(log.habitId)
+    log => log.status === "complete" && activeHabitIds.includes(log.habitId)
   ).length;
   const completionRate = totalHabits > 0 ? (completedHabits / totalHabits) * 100 : 0;
   

--- a/client/src/components/stats/HabitCharts.tsx
+++ b/client/src/components/stats/HabitCharts.tsx
@@ -87,7 +87,7 @@ export function HabitCharts() {
     const habitIds = categoryHabits.map(habit => habit.id);
     
     const totalLogs = habitLogs.filter(log => habitIds.includes(log.habitId)).length;
-    const completedLogs = habitLogs.filter(log => habitIds.includes(log.habitId) && log.completed).length;
+    const completedLogs = habitLogs.filter(log => habitIds.includes(log.habitId) && log.status === "complete").length;
     
     const completionRate = totalLogs > 0 ? (completedLogs / totalLogs) * 100 : 0;
     
@@ -126,7 +126,7 @@ export function HabitCharts() {
       );
     });
 
-    const completedLogs = dayLogs.filter(log => log.completed).length;
+    const completedLogs = dayLogs.filter(log => log.status === "complete").length;
 
     const completionRate = activeHabits.length > 0
       ? (completedLogs / activeHabits.length) * 100

--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -61,7 +61,7 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
     
     if (logsForDay.length === 0) return 0;
     
-    const completedCount = logsForDay.filter(log => log.completed).length;
+    const completedCount = logsForDay.filter(log => log.status === "complete").length;
     return completedCount / logsForDay.length;
   };
   

--- a/client/src/pages/statistics.tsx
+++ b/client/src/pages/statistics.tsx
@@ -29,7 +29,7 @@ export default function Statistics() {
   
   // Calculate overall stats
   const totalHabits = habits?.length || 0;
-  const completedToday = todayLogs?.filter(log => log.completed).length || 0;
+  const completedToday = todayLogs?.filter(log => log.status === "complete").length || 0;
   const completionRate = totalHabits > 0 ? (completedToday / totalHabits) * 100 : 0;
   
   return (

--- a/migrations/20250216_update_habit_logs_status.sql
+++ b/migrations/20250216_update_habit_logs_status.sql
@@ -1,0 +1,47 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'habit_status') THEN
+    CREATE TYPE habit_status AS ENUM ('incomplete', 'partial', 'complete');
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  has_habit_logs boolean;
+  has_completed_column boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'habit_logs'
+  ) INTO has_habit_logs;
+
+  IF has_habit_logs THEN
+    ALTER TABLE habit_logs ADD COLUMN IF NOT EXISTS status habit_status;
+
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'habit_logs' AND column_name = 'completed'
+    ) INTO has_completed_column;
+
+    IF has_completed_column THEN
+      UPDATE habit_logs
+      SET status = CASE
+        WHEN completed IS TRUE THEN 'complete'::habit_status
+        WHEN completed IS FALSE THEN 'incomplete'::habit_status
+        ELSE 'incomplete'::habit_status
+      END
+      WHERE status IS NULL;
+    END IF;
+
+    UPDATE habit_logs
+    SET status = COALESCE(status, 'incomplete'::habit_status)
+    WHERE status IS NULL;
+
+    ALTER TABLE habit_logs ALTER COLUMN status SET DEFAULT 'incomplete';
+    ALTER TABLE habit_logs ALTER COLUMN status SET NOT NULL;
+
+    IF has_completed_column THEN
+      ALTER TABLE habit_logs DROP COLUMN completed;
+    END IF;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- replace the habit log completion boolean with a habit_status enum and expose it through the shared schema
- migrate stored data, update storage logic, and allow the toggle endpoint to accept explicit status values
- update client components and metrics to understand the new status values and show partial progress in the UI

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f955337cf88327920bc3f9d7d5ae5c