### PR TITLE
feat: add explicit habit status controls

### DIFF
--- a/client/src/components/habits/HabitList.tsx
+++ b/client/src/components/habits/HabitList.tsx
@@ -44,7 +44,14 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
         {[1, 2, 3, 4].map((i) => (
           <div key={i} className="bg-white rounded-xl shadow-sm p-4">
             <div className="flex gap-3">
-              <Skeleton className="h-6 w-6 rounded-full" />
+              <div className="flex flex-col items-center gap-1">
+                <div className="flex items-center gap-1">
+                  {[1, 2, 3].map((status) => (
+                    <Skeleton key={status} className="h-8 w-8 rounded-full" />
+                  ))}
+                </div>
+                <Skeleton className="h-3 w-12" />
+              </div>
               <div className="flex-grow">
                 <div className="flex items-center justify-between">
                   <Skeleton className="h-5 w-48" />

--- a/client/src/pages/statistics.tsx
+++ b/client/src/pages/statistics.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Habit, HabitLog } from "@shared/schema";
+import { Habit, HabitLog, HabitStatus } from "@shared/schema";
 import { formatDisplayDate, formatDate } from "@/lib/dates";
 import { HabitCharts } from "@/components/stats/HabitCharts";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -27,10 +27,18 @@ export default function Statistics() {
   
   const isLoading = isLoadingHabits || isLoadingLogs;
   
+  const statusWeights: Record<HabitStatus, number> = {
+    complete: 1,
+    partial: 0.5,
+    incomplete: 0,
+  };
+
   // Calculate overall stats
   const totalHabits = habits?.length || 0;
   const completedToday = todayLogs?.filter(log => log.status === "complete").length || 0;
-  const completionRate = totalHabits > 0 ? (completedToday / totalHabits) * 100 : 0;
+  const partialToday = todayLogs?.filter(log => log.status === "partial").length || 0;
+  const weightedToday = todayLogs?.reduce((sum, log) => sum + statusWeights[log.status], 0) || 0;
+  const completionRate = totalHabits > 0 ? (weightedToday / totalHabits) * 100 : 0;
   
   return (
     <div className="p-4 md:p-6">
@@ -52,11 +60,17 @@ export default function Statistics() {
         </div>
         
         <div className="bg-white rounded-xl shadow-sm p-4">
-          <h3 className="text-sm text-gray-600 mb-1">Completed Today</h3>
+          <h3 className="text-sm text-gray-600 mb-1">Today's Progress</h3>
           {isLoading ? (
-            <Skeleton className="h-8 w-16" />
+            <>
+              <Skeleton className="h-8 w-16" />
+              <Skeleton className="h-4 w-20 mt-2" />
+            </>
           ) : (
-            <p className="text-2xl font-bold">{completedToday}</p>
+            <div>
+              <p className="text-2xl font-bold">{completedToday} complete</p>
+              <p className="text-sm text-warning mt-1">{partialToday} partial</p>
+            </div>
           )}
         </div>
         


### PR DESCRIPTION
## Summary
- replace the HabitCard toggle with a three-state status selector and enrich toasts for each outcome
- update optimistic cache, weekly calendar, and stats widgets to honor complete/partial/incomplete colors and weights
- refresh list skeletons and progress displays to show the new status styles and metrics

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fa8ef7e3888327ac789bd2449c3a73