### PR TITLE
Treat partial habit logs separately from completion metrics

### DIFF
--- a/client/src/components/ReminderChecker.tsx
+++ b/client/src/components/ReminderChecker.tsx
@@ -43,15 +43,20 @@ const ReminderChecker = ({ habits }: Props) => {
 
         if (!isHabitActiveOnDate(habit, now)) return;
 
-        const doneToday = habitLogs?.some(
+        const todayLog = habitLogs?.find(
           (log) =>
             log.habitId === habit.id &&
-            log.status === "complete" &&
             log.date.startsWith(todayIso)
         );
 
-        if (!doneToday && currentHour >= reminderHour) {
-          toast.info(`Reminder: ${habit.name}`);
+        const isComplete = todayLog?.status === "complete";
+        const isPartial = todayLog?.status === "partial";
+
+        if (!isComplete && currentHour >= reminderHour) {
+          const message = isPartial
+            ? `Keep going: ${habit.name} is partially complete`
+            : `Reminder: ${habit.name}`;
+          toast.info(message);
           remindedIds.current.add(habit.id);
         }
       });

--- a/client/src/components/stats/CircularProgressDisplay.tsx
+++ b/client/src/components/stats/CircularProgressDisplay.tsx
@@ -1,6 +1,6 @@
 import { CircularProgress } from "@/components/ui/circular-progress";
 import { useQuery } from "@tanstack/react-query";
-import { HabitLog, Habit, HabitStatus } from "@shared/schema";
+import { HabitLog, Habit } from "@shared/schema";
 import { formatDate, parseLocalDate } from "@/lib/dates";
 import { isHabitActiveOnDate } from "@/lib/habitUtils";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -74,12 +74,6 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
     );
   }
   
-  const statusWeights: Record<HabitStatus, number> = {
-    complete: 1,
-    partial: 0.5,
-    incomplete: 0,
-  };
-
   // Calculate completion statistics based on habits active for the selected date
   const dateObj = parseLocalDate(date);
   const activeHabits = habits.filter(habit => isHabitActiveOnDate(habit, dateObj));
@@ -88,8 +82,7 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
   const dailyLogs = habitLogs.filter(log => activeHabitIds.includes(log.habitId));
   const completedHabits = dailyLogs.filter((log) => log.status === "complete").length;
   const partialHabits = dailyLogs.filter((log) => log.status === "partial").length;
-  const weightedScore = dailyLogs.reduce((sum, log) => sum + statusWeights[log.status], 0);
-  const completionRate = totalHabits > 0 ? (weightedScore / totalHabits) * 100 : 0;
+  const completionRate = totalHabits > 0 ? (completedHabits / totalHabits) * 100 : 0;
   
   return (
     <div className="bg-white rounded-xl shadow-sm p-4 mb-6">

--- a/docs/MANUAL_QA.md
+++ b/docs/MANUAL_QA.md
@@ -1,0 +1,23 @@
+# Manual QA - Completion Status Updates
+
+## Charts and Statistics
+1. Log in as a user with multiple habits.
+2. Ensure at least one habit has entries for **complete**, **partial**, and **incomplete** within the last month.
+3. Navigate to **Statistics**.
+   - Confirm the "Today's Progress" card shows complete counts in bold and partial counts in warning text.
+   - Confirm the completion rate percentage only reflects fully completed habits.
+   - Hover over bars and the trend line in "Habit Performance" and verify the tooltip text includes the complete/total summary and partial counts when present.
+4. From the **Weekly Overview** calendar, verify days with mixed statuses are marked as partial, fully complete days are green, and incomplete days are red.
+
+## Streaks
+1. Navigate to the dashboard Habit list.
+2. For a habit with a current streak, mark the most recent day as **partial** and ensure the streak count resets to zero.
+3. Mark the same day as **complete** and confirm the streak count resumes (e.g., increases from the previous day).
+4. Repeat for multiple days to verify the streak only progresses when the status is "complete".
+
+## Reminders
+1. Configure a habit with a reminder time that has already passed (e.g., morning reminder after 9 AM).
+2. Log the habit as **partial** for today.
+   - Confirm the reminder toast reads “Keep going: … is partially complete.”
+3. Update the habit to **complete** and ensure no further reminder toasts appear.
+4. Create a different habit with no status logged and wait for the reminder window; confirm the toast uses the generic reminder message.


### PR DESCRIPTION
## Summary
- update statistics and chart helpers so only fully complete logs count toward completion rates while still surfacing partial counts
- fetch a 30-day log window for streak calculations so streaks extend only when the latest status is complete
- adjust reminder messaging when a habit is only partially complete and add manual QA coverage for charts, streaks, and reminders

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fa9433ffa08327873d52747af8fcb4