### PR TITLE
Handle habit status updates with new payload

### DIFF
--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { HabitLog, HabitStatus } from "@shared/schema";
+import { HabitLog } from "@shared/schema";
 import { 
   getCurrentWeekDates, 
   getPreviousWeekDates, 
@@ -53,7 +53,7 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
     setWeekDates(getNextWeekDates(weekDates.start));
   };
   
-  type DayStatus = HabitStatus | "none";
+  type DayStatus = HabitLog["status"] | "none";
 
   const getDayStatus = (date: Date): DayStatus => {
     if (!habitLogs) return "none";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -51,8 +51,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   };
 
   const habitStatusUpdateSchema = z.object({
-    date: z.string(),
     status: z.enum(habitStatusEnum.enumValues).optional(),
+  });
+  const habitStatusQuerySchema = z.object({
+    date: z.string(),
   });
 
   // Categories routes
@@ -234,7 +236,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/habits/:habitId/toggle", isAuthenticated, async (req, res) => {
     try {
       const habitId = parseInt(req.params.habitId);
-      const { date, status } = habitStatusUpdateSchema.parse(req.body);
+      const { date } = habitStatusQuerySchema.parse(req.query);
+      const { status } = habitStatusUpdateSchema.parse(req.body);
 
       // Ensure it's the user's habit
       const habit = await storage.getHabit(habitId);


### PR DESCRIPTION
## Summary
- extend the shared apiRequest helper to support query parameters for mutations
- update the habit status endpoint to accept the date via query string while posting the new { status } payload
- refresh the HabitCard mutation and client typing to use HabitLog status unions and keep cache entries in sync

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fa97173784832787ba5431a308ca93