### PR TITLE
feat: unify status styling across habit UI

### DIFF
--- a/client/src/components/habits/HabitCard.tsx
+++ b/client/src/components/habits/HabitCard.tsx
@@ -90,19 +90,19 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
 
   const toneClasses: Record<"success" | "warning" | "destructive", { active: string; inactive: string; icon: string }> = {
     success: {
-      active: "bg-success text-success-foreground shadow-sm",
-      inactive: "border border-success/40 text-success hover:bg-success/10",
-      icon: "text-success",
+      active: "status-button status-button--success",
+      inactive: "status-button status-button--success-muted",
+      icon: "status-icon status-icon--success",
     },
     warning: {
-      active: "bg-warning text-warning-foreground shadow-sm",
-      inactive: "border border-warning/40 text-warning hover:bg-warning/10",
-      icon: "text-warning",
+      active: "status-button status-button--warning",
+      inactive: "status-button status-button--warning-muted",
+      icon: "status-icon status-icon--warning",
     },
     destructive: {
-      active: "bg-destructive text-destructive-foreground shadow-sm",
-      inactive: "border border-destructive/40 text-destructive hover:bg-destructive/10",
-      icon: "text-destructive",
+      active: "status-button status-button--danger",
+      inactive: "status-button status-button--danger-muted",
+      icon: "status-icon status-icon--danger",
     },
   };
   
@@ -212,7 +212,7 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
         title: message.title,
         description: (
           <div className="flex items-start gap-2">
-            <message.Icon className={cn("mt-0.5 h-4 w-4", toneClasses[message.tone].icon)} />
+            <message.Icon className={cn("mt-0.5", toneClasses[message.tone].icon)} />
             <span>{message.description}</span>
           </div>
         ),
@@ -301,7 +301,6 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
                     aria-pressed={isActive}
                     aria-label={`Mark as ${option.label}`}
                     className={cn(
-                      "flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium transition-all duration-200",
                       isActive ? classes.active : classes.inactive,
                       isPending && !isActive && "opacity-60",
                       isPending && "cursor-not-allowed"

--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -80,20 +80,20 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
 
   const dayToneClasses: Record<DayStatus, { button: string; bar: string }> = {
     complete: {
-      button: "bg-success text-success-foreground hover:bg-success/90",
-      bar: "bg-success",
+      button: "status-tile status-tile--success",
+      bar: "status-meter--success",
     },
     partial: {
-      button: "bg-warning text-warning-foreground hover:bg-warning/90",
-      bar: "bg-warning",
+      button: "status-tile status-tile--warning",
+      bar: "status-meter--warning",
     },
     incomplete: {
-      button: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-      bar: "bg-destructive",
+      button: "status-tile status-tile--danger",
+      bar: "status-meter--danger",
     },
     none: {
-      button: "bg-gray-100 text-gray-700 hover:bg-gray-200",
-      bar: "bg-gray-300",
+      button: "status-tile status-tile--neutral",
+      bar: "status-meter--neutral",
     },
   };
   
@@ -158,8 +158,8 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
               <button
                 onClick={() => onSelectDate(dateStr)}
                 className={cn(
-                  "w-10 h-10 rounded-lg flex items-center justify-center text-sm font-medium transition-colors",
-                  dayIsToday && dayStatus === "none" ? "bg-primary/10 text-primary" : tone.button,
+                  tone.button,
+                  dayIsToday && dayStatus === "none" && "status-tile--today",
                   isSelected && "ring-2 ring-offset-2 ring-primary"
                 )}
               >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,3 +11,105 @@
     @apply font-sans antialiased bg-background text-foreground;
   }
 }
+
+@layer components {
+  .status-badge {
+    @apply inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide;
+  }
+
+  .status-badge--success {
+    @apply bg-success text-success-foreground;
+  }
+
+  .status-badge--warning {
+    @apply bg-warning text-warning-foreground;
+  }
+
+  .status-badge--danger {
+    @apply bg-destructive text-destructive-foreground;
+  }
+
+  .status-button {
+    @apply flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2;
+  }
+
+  .status-button--success {
+    @apply bg-success text-success-foreground shadow-sm hover:bg-success/90 focus-visible:ring-success/40;
+  }
+
+  .status-button--success-muted {
+    @apply border border-success/50 bg-white text-success hover:bg-success/10 focus-visible:ring-success/30;
+  }
+
+  .status-button--warning {
+    @apply bg-warning text-warning-foreground shadow-sm hover:bg-warning/90 focus-visible:ring-warning/40;
+  }
+
+  .status-button--warning-muted {
+    @apply border border-warning/50 bg-white text-warning hover:bg-warning/10 focus-visible:ring-warning/30;
+  }
+
+  .status-button--danger {
+    @apply bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 focus-visible:ring-destructive/40;
+  }
+
+  .status-button--danger-muted {
+    @apply border border-destructive/50 bg-white text-destructive hover:bg-destructive/10 focus-visible:ring-destructive/30;
+  }
+
+  .status-icon {
+    @apply h-4 w-4;
+  }
+
+  .status-icon--success {
+    @apply text-success;
+  }
+
+  .status-icon--warning {
+    @apply text-warning;
+  }
+
+  .status-icon--danger {
+    @apply text-destructive;
+  }
+
+  .status-tile {
+    @apply flex h-10 w-10 items-center justify-center rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2;
+  }
+
+  .status-tile--success {
+    @apply bg-success text-success-foreground hover:bg-success/90 focus-visible:ring-success/40;
+  }
+
+  .status-tile--warning {
+    @apply bg-warning text-warning-foreground hover:bg-warning/90 focus-visible:ring-warning/40;
+  }
+
+  .status-tile--danger {
+    @apply bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/40;
+  }
+
+  .status-tile--neutral {
+    @apply bg-gray-100 text-gray-700 hover:bg-gray-200 focus-visible:ring-gray-300;
+  }
+
+  .status-tile--today {
+    @apply bg-primary/10 text-primary hover:bg-primary/20 focus-visible:ring-primary/40;
+  }
+
+  .status-meter--success {
+    @apply bg-success;
+  }
+
+  .status-meter--warning {
+    @apply bg-warning;
+  }
+
+  .status-meter--danger {
+    @apply bg-destructive;
+  }
+
+  .status-meter--neutral {
+    @apply bg-gray-300;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,15 +38,15 @@ export default {
           foreground: "hsl(var(--accent-foreground))",
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: "hsl(354, 70%, 42%)",
+          foreground: "hsl(0, 0%, 100%)",
         },
         success: {
-          DEFAULT: "hsl(142, 76%, 36%)",
+          DEFAULT: "hsl(142, 70%, 30%)",
           foreground: "hsl(0, 0%, 100%)",
         },
         warning: {
-          DEFAULT: "hsl(32, 94%, 62%)",
+          DEFAULT: "hsl(32, 84%, 36%)",
           foreground: "hsl(0, 0%, 100%)",
         },
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Summary
- add shared status utility classes for success, warning, and danger surfaces in the client styles
- refactor the habit card status controls and weekly calendar tiles to reuse the shared status styles
- adjust status palette hues to maintain accessible contrast for red, yellow, and green surfaces

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68fa9de3a9f88327b4d3eabcce084d90