### PR TITLE
Add not applicable habit status and update analytics

### DIFF
--- a/client/src/components/ReminderChecker.tsx
+++ b/client/src/components/ReminderChecker.tsx
@@ -51,8 +51,9 @@ const ReminderChecker = ({ habits }: Props) => {
 
         const isComplete = todayLog?.status === "complete";
         const isPartial = todayLog?.status === "partial";
+        const isNotApplicable = todayLog?.status === "not_applicable";
 
-        if (!isComplete && currentHour >= reminderHour) {
+        if (!isComplete && !isNotApplicable && currentHour >= reminderHour) {
           const message = isPartial
             ? `Keep going: ${habit.name} is partially complete`
             : `Reminder: ${habit.name}`;

--- a/client/src/components/habits/HabitCard.tsx
+++ b/client/src/components/habits/HabitCard.tsx
@@ -7,6 +7,7 @@ import {
   MoreVerticalIcon,
   XIcon,
   LucideIcon,
+  MinusIcon,
 } from "lucide-react";
 import { useState } from "react";
 import { apiRequest } from "@/lib/queryClient";
@@ -62,7 +63,7 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
     value: HabitLogStatus;
     label: string;
     icon: LucideIcon;
-    tone: "success" | "warning" | "destructive";
+    tone: "success" | "warning" | "destructive" | "neutral";
     helper: string;
   }> = [
     {
@@ -86,9 +87,16 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
       tone: "destructive",
       helper: "Not yet started",
     },
+    {
+      value: "not_applicable",
+      label: "Not applicable",
+      icon: MinusIcon,
+      tone: "neutral",
+      helper: "Doesn't apply today",
+    },
   ];
 
-  const toneClasses: Record<"success" | "warning" | "destructive", { active: string; inactive: string; icon: string }> = {
+  const toneClasses: Record<"success" | "warning" | "destructive" | "neutral", { active: string; inactive: string; icon: string }> = {
     success: {
       active: "status-button status-button--success",
       inactive: "status-button status-button--success-muted",
@@ -103,6 +111,11 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
       active: "status-button status-button--danger",
       inactive: "status-button status-button--danger-muted",
       icon: "status-icon status-icon--danger",
+    },
+    neutral: {
+      active: "status-button status-button--neutral",
+      inactive: "status-button status-button--neutral-muted",
+      icon: "status-icon status-icon--neutral",
     },
   };
   
@@ -203,6 +216,12 @@ export function HabitCard({ habit, categories, logs = [], date = formatDate(new 
           description: "You can still complete it later!",
           Icon: XIcon,
           tone: "destructive",
+        },
+        not_applicable: {
+          title: "Marked as not applicable",
+          description: "We'll skip this habit for now.",
+          Icon: MinusIcon,
+          tone: "neutral",
         },
       };
 

--- a/client/src/components/habits/HabitList.tsx
+++ b/client/src/components/habits/HabitList.tsx
@@ -49,7 +49,7 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
             <div className="flex gap-3">
               <div className="flex flex-col items-center gap-1">
                 <div className="flex items-center gap-1">
-                  {[1, 2, 3].map((status) => (
+                  {[1, 2, 3, 4].map((status) => (
                     <Skeleton key={status} className="h-8 w-8 rounded-full" />
                   ))}
                 </div>

--- a/client/src/components/stats/CircularProgressDisplay.tsx
+++ b/client/src/components/stats/CircularProgressDisplay.tsx
@@ -80,9 +80,11 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
   const activeHabitIds = activeHabits.map(h => h.id);
   const totalHabits = activeHabits.length;
   const dailyLogs = habitLogs.filter(log => activeHabitIds.includes(log.habitId));
+  const notApplicableHabits = dailyLogs.filter((log) => log.status === "not_applicable").length;
+  const actionableHabits = Math.max(totalHabits - notApplicableHabits, 0);
   const completedHabits = dailyLogs.filter((log) => log.status === "complete").length;
   const partialHabits = dailyLogs.filter((log) => log.status === "partial").length;
-  const completionRate = totalHabits > 0 ? (completedHabits / totalHabits) * 100 : 0;
+  const completionRate = actionableHabits > 0 ? (completedHabits / actionableHabits) * 100 : 0;
   
   return (
     <div className="bg-white rounded-xl shadow-sm p-4 mb-6">
@@ -90,7 +92,10 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
         <div>
           <h4 className="text-sm text-gray-600">Progress</h4>
           <p className="text-2xl font-bold">{Math.round(completionRate)}%</p>
-          <p className="text-xs text-gray-500">{completedHabits} complete · {partialHabits} partial</p>
+          <p className="text-xs text-gray-500">
+            {completedHabits} complete · {partialHabits} partial
+            {notApplicableHabits > 0 ? ` · ${notApplicableHabits} not applicable` : ""}
+          </p>
         </div>
         <div className="w-32 h-32">
           <CircularProgress

--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -65,6 +65,11 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
       return "none";
     }
 
+    const allNotApplicable = logsForDay.every((log) => log.status === "not_applicable");
+    if (allNotApplicable) {
+      return "not_applicable";
+    }
+
     const allComplete = logsForDay.every((log) => log.status === "complete");
     if (allComplete) {
       return "complete";
@@ -90,6 +95,10 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
     incomplete: {
       button: "status-tile status-tile--danger",
       bar: "status-meter--danger",
+    },
+    not_applicable: {
+      button: "status-tile status-tile--neutral",
+      bar: "status-meter--neutral",
     },
     none: {
       button: "status-tile status-tile--neutral",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -57,6 +57,14 @@
     @apply border border-destructive/50 bg-white text-destructive hover:bg-destructive/10 focus-visible:ring-destructive/30;
   }
 
+  .status-button--neutral {
+    @apply bg-gray-200 text-gray-700 shadow-sm hover:bg-gray-300 focus-visible:ring-gray-300;
+  }
+
+  .status-button--neutral-muted {
+    @apply border border-gray-300 bg-white text-gray-500 hover:bg-gray-100 focus-visible:ring-gray-200;
+  }
+
   .status-icon {
     @apply h-4 w-4;
   }
@@ -71,6 +79,10 @@
 
   .status-icon--danger {
     @apply text-destructive;
+  }
+
+  .status-icon--neutral {
+    @apply text-gray-500;
   }
 
   .status-tile {

--- a/client/src/pages/statistics.tsx
+++ b/client/src/pages/statistics.tsx
@@ -35,8 +35,10 @@ export default function Statistics() {
   const todayActiveLogs = todayLogs?.filter(log => activeHabitIds.has(log.habitId)) ?? [];
   const completedToday = todayActiveLogs.filter(log => log.status === "complete").length;
   const partialToday = todayActiveLogs.filter(log => log.status === "partial").length;
-  const completionRate = activeHabitsToday.length > 0
-    ? (completedToday / activeHabitsToday.length) * 100
+  const notApplicableToday = todayActiveLogs.filter(log => log.status === "not_applicable").length;
+  const actionableHabits = Math.max(activeHabitsToday.length - notApplicableToday, 0);
+  const completionRate = actionableHabits > 0
+    ? (completedToday / actionableHabits) * 100
     : 0;
   
   return (
@@ -69,6 +71,9 @@ export default function Statistics() {
             <div>
               <p className="text-2xl font-bold">{completedToday} complete</p>
               <p className="text-sm text-warning mt-1">{partialToday} partial</p>
+              {notApplicableToday > 0 && (
+                <p className="text-sm text-gray-500 mt-1">{notApplicableToday} not applicable</p>
+              )}
             </div>
           )}
         </div>

--- a/migrations/20250304_expand_habit_status_enum.sql
+++ b/migrations/20250304_expand_habit_status_enum.sql
@@ -1,0 +1,54 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'habit_status') THEN
+    CREATE TYPE habit_status AS ENUM ('incomplete', 'partial', 'complete', 'not_applicable');
+  ELSE
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_enum e
+      JOIN pg_type t ON e.enumtypid = t.oid
+      WHERE t.typname = 'habit_status' AND e.enumlabel = 'not_applicable'
+    ) THEN
+      ALTER TYPE habit_status ADD VALUE 'not_applicable';
+    END IF;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  has_completed_column boolean;
+BEGIN
+  PERFORM 1
+  FROM information_schema.tables
+  WHERE table_schema = 'public' AND table_name = 'habit_logs';
+
+  IF FOUND THEN
+    ALTER TABLE habit_logs ADD COLUMN IF NOT EXISTS status habit_status;
+
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'habit_logs'
+        AND column_name = 'completed'
+    ) INTO has_completed_column;
+
+    IF has_completed_column THEN
+      UPDATE habit_logs
+      SET status = CASE
+        WHEN completed IS TRUE THEN 'complete'::habit_status
+        WHEN completed IS FALSE THEN 'incomplete'::habit_status
+        ELSE COALESCE(status, 'incomplete'::habit_status)
+      END
+      WHERE status IS NULL OR completed IS NOT NULL;
+
+      ALTER TABLE habit_logs DROP COLUMN completed;
+    END IF;
+
+    UPDATE habit_logs
+    SET status = COALESCE(status, 'incomplete'::habit_status)
+    WHERE status IS NULL;
+
+    ALTER TABLE habit_logs ALTER COLUMN status SET DEFAULT 'incomplete';
+    ALTER TABLE habit_logs ALTER COLUMN status SET NOT NULL;
+  END IF;
+END $$;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -273,7 +273,15 @@ export class MemStorage implements IStorage {
     const existingLog = await this.getHabitLog(habitId, date);
 
     if (existingLog) {
-      const nextStatus = status ?? (existingLog.status === "complete" ? "incomplete" : "complete");
+      const cycleStatus = (current: HabitStatus): HabitStatus => {
+        if (current === "complete") return "incomplete";
+        if (current === "partial" || current === "incomplete" || current === "not_applicable") {
+          return "complete";
+        }
+        return "complete";
+      };
+
+      const nextStatus = status ?? cycleStatus(existingLog.status);
 
       const updated = await this.updateHabitLog(existingLog.id, {
         status: nextStatus
@@ -527,7 +535,15 @@ export class DatabaseStorage implements IStorage {
     const existingLog = await this.getHabitLog(habitId, normalizedDate);
 
     if (existingLog) {
-      const nextStatus = status ?? (existingLog.status === "complete" ? "incomplete" : "complete");
+      const cycleStatus = (current: HabitStatus): HabitStatus => {
+        if (current === "complete") return "incomplete";
+        if (current === "partial" || current === "incomplete" || current === "not_applicable") {
+          return "complete";
+        }
+        return "complete";
+      };
+
+      const nextStatus = status ?? cycleStatus(existingLog.status);
 
       const updated = await this.updateHabitLog(existingLog.id, {
         status: nextStatus

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -56,6 +56,7 @@ export const habitStatusEnum = pgEnum("habit_status", [
   "incomplete",
   "partial",
   "complete",
+  "not_applicable",
 ]);
 
 export const habitLogs = pgTable("habit_logs", {
@@ -72,7 +73,7 @@ export const insertHabitLogSchema = createInsertSchema(habitLogs).pick({
   date: true,
   status: true,
 }).extend({
-  status: z.enum(habitStatusEnum.enumValues).optional(),
+  status: z.enum(habitStatusEnum.enumValues).default("incomplete"),
 });
 
 // Types


### PR DESCRIPTION
## Summary
- expand the shared habit status enum with a not_applicable option and provide a migration that backfills legacy data safely
- guard storage toggles from cycling into the not_applicable state unless explicitly requested while keeping defaults on incomplete
- surface the new status across UI controls and analytics so not-applicable entries are styled, selectable, and excluded from completion rates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fb9d67f9dc83279bf5ae7ee4a2d2b1