### PR TITLE
Handle not applicable habit logs in analytics and streaks

### DIFF
--- a/client/src/components/ReminderChecker.tsx
+++ b/client/src/components/ReminderChecker.tsx
@@ -49,6 +49,11 @@ const ReminderChecker = ({ habits }: Props) => {
             log.date.startsWith(todayIso)
         );
 
+        if (todayLog?.status === "not_applicable") {
+          remindedIds.current.add(habit.id);
+          return;
+        }
+
         const isComplete = todayLog?.status === "complete";
         const isPartial = todayLog?.status === "partial";
 

--- a/client/src/components/habits/HabitList.tsx
+++ b/client/src/components/habits/HabitList.tsx
@@ -92,11 +92,18 @@ export function HabitList({ selectedCategory, date = formatDate(new Date()) }: H
   const calculateHabitStreaks = (habitId: number) => {
     if (!habitLogs) return 0;
     
-    const completedDates = (habitLogs as HabitLog[])
-      .filter((log: HabitLog) => log.habitId === habitId && log.status === "complete")
+    const habitSpecificLogs = (habitLogs as HabitLog[]).filter(
+      (log: HabitLog) => log.habitId === habitId
+    );
+
+    const completedDates = habitSpecificLogs
+      .filter((log: HabitLog) => log.status === "complete")
       .map((log: HabitLog) => parseLocalDate(log.date));
-    
-    return getStreakCount(completedDates);
+    const skippedDates = habitSpecificLogs
+      .filter((log: HabitLog) => log.status === "not_applicable")
+      .map((log: HabitLog) => parseLocalDate(log.date));
+
+    return getStreakCount(completedDates, skippedDates);
   };
 
   // Filter logs for the selected date

--- a/client/src/components/stats/CircularProgressDisplay.tsx
+++ b/client/src/components/stats/CircularProgressDisplay.tsx
@@ -78,11 +78,12 @@ export function CircularProgressDisplay({ date = formatDate(new Date()) }: Circu
   const dateObj = parseLocalDate(date);
   const activeHabits = habits.filter(habit => isHabitActiveOnDate(habit, dateObj));
   const activeHabitIds = activeHabits.map(h => h.id);
-  const totalHabits = activeHabits.length;
   const dailyLogs = habitLogs.filter(log => activeHabitIds.includes(log.habitId));
+  const notApplicableCount = dailyLogs.filter((log) => log.status === "not_applicable").length;
+  const applicableTotal = Math.max(activeHabits.length - notApplicableCount, 0);
   const completedHabits = dailyLogs.filter((log) => log.status === "complete").length;
   const partialHabits = dailyLogs.filter((log) => log.status === "partial").length;
-  const completionRate = totalHabits > 0 ? (completedHabits / totalHabits) * 100 : 0;
+  const completionRate = applicableTotal > 0 ? (completedHabits / applicableTotal) * 100 : 0;
   
   return (
     <div className="bg-white rounded-xl shadow-sm p-4 mb-6">

--- a/client/src/components/stats/HabitCharts.tsx
+++ b/client/src/components/stats/HabitCharts.tsx
@@ -87,9 +87,10 @@ export function HabitCharts() {
     const habitIds = categoryHabits.map(habit => habit.id);
 
     const relevantLogs = habitLogs.filter(log => habitIds.includes(log.habitId));
-    const totalLogs = relevantLogs.length;
-    const completeCount = relevantLogs.filter(log => log.status === "complete").length;
-    const partialCount = relevantLogs.filter(log => log.status === "partial").length;
+    const applicableLogs = relevantLogs.filter(log => log.status !== "not_applicable");
+    const totalLogs = applicableLogs.length;
+    const completeCount = applicableLogs.filter(log => log.status === "complete").length;
+    const partialCount = applicableLogs.filter(log => log.status === "partial").length;
 
     const completionRate = totalLogs > 0 ? (completeCount / totalLogs) * 100 : 0;
 
@@ -131,10 +132,13 @@ export function HabitCharts() {
       );
     });
 
-    const completeCount = dayLogs.filter(log => log.status === "complete").length;
-    const partialCount = dayLogs.filter(log => log.status === "partial").length;
-    const completionRate = activeHabits.length > 0
-      ? (completeCount / activeHabits.length) * 100
+    const applicableLogs = dayLogs.filter(log => log.status !== "not_applicable");
+    const notApplicableCount = dayLogs.length - applicableLogs.length;
+    const completeCount = applicableLogs.filter(log => log.status === "complete").length;
+    const partialCount = applicableLogs.filter(log => log.status === "partial").length;
+    const applicableActiveCount = Math.max(activeHabits.length - notApplicableCount, 0);
+    const completionRate = applicableActiveCount > 0
+      ? (completeCount / applicableActiveCount) * 100
       : 0;
 
     return {
@@ -143,7 +147,7 @@ export function HabitCharts() {
       rate: Math.round(completionRate),
       complete: completeCount,
       partial: partialCount,
-      active: activeHabits.length,
+      active: applicableActiveCount,
     };
   });
   

--- a/client/src/components/stats/WeeklyCalendar.tsx
+++ b/client/src/components/stats/WeeklyCalendar.tsx
@@ -60,17 +60,18 @@ export function WeeklyCalendar({ onSelectDate, selectedDate }: WeeklyCalendarPro
 
     const formattedDate = formatDate(date);
     const logsForDay = habitLogs.filter(log => formatDate(parseLocalDate(log.date)) === formattedDate);
+    const applicableLogs = logsForDay.filter(log => log.status !== "not_applicable");
 
-    if (logsForDay.length === 0) {
+    if (applicableLogs.length === 0) {
       return "none";
     }
 
-    const allComplete = logsForDay.every((log) => log.status === "complete");
+    const allComplete = applicableLogs.every((log) => log.status === "complete");
     if (allComplete) {
       return "complete";
     }
 
-    const allIncomplete = logsForDay.every((log) => log.status === "incomplete");
+    const allIncomplete = applicableLogs.every((log) => log.status === "incomplete");
     if (allIncomplete) {
       return "incomplete";
     }

--- a/client/src/pages/statistics.tsx
+++ b/client/src/pages/statistics.tsx
@@ -33,10 +33,13 @@ export default function Statistics() {
   const activeHabitsToday = habits?.filter(habit => isHabitActiveOnDate(habit, today)) ?? [];
   const activeHabitIds = new Set(activeHabitsToday.map(habit => habit.id));
   const todayActiveLogs = todayLogs?.filter(log => activeHabitIds.has(log.habitId)) ?? [];
-  const completedToday = todayActiveLogs.filter(log => log.status === "complete").length;
-  const partialToday = todayActiveLogs.filter(log => log.status === "partial").length;
-  const completionRate = activeHabitsToday.length > 0
-    ? (completedToday / activeHabitsToday.length) * 100
+  const applicableTodayLogs = todayActiveLogs.filter(log => log.status !== "not_applicable");
+  const notApplicableToday = todayActiveLogs.length - applicableTodayLogs.length;
+  const completedToday = applicableTodayLogs.filter(log => log.status === "complete").length;
+  const partialToday = applicableTodayLogs.filter(log => log.status === "partial").length;
+  const applicableActiveCount = Math.max(activeHabitsToday.length - notApplicableToday, 0);
+  const completionRate = applicableActiveCount > 0
+    ? (completedToday / applicableActiveCount) * 100
     : 0;
   
   return (

--- a/docs/MANUAL_QA.md
+++ b/docs/MANUAL_QA.md
@@ -2,22 +2,25 @@
 
 ## Charts and Statistics
 1. Log in as a user with multiple habits.
-2. Ensure at least one habit has entries for **complete**, **partial**, and **incomplete** within the last month.
+2. Ensure at least one habit has entries for **complete**, **partial**, **incomplete**, and **not applicable** within the last month.
 3. Navigate to **Statistics**.
    - Confirm the "Today's Progress" card shows complete counts in bold and partial counts in warning text.
    - Confirm the completion rate percentage only reflects fully completed habits.
+   - Mark one habit as **not applicable** for today and verify the Progress card removes it from the total habit count and percentage.
    - Hover over bars and the trend line in "Habit Performance" and verify the tooltip text includes the complete/total summary and partial counts when present.
-4. From the **Weekly Overview** calendar, verify days with mixed statuses are marked as partial, fully complete days are green, and incomplete days are red.
+4. From the **Weekly Overview** calendar, verify days with mixed statuses are marked as partial, fully complete days are green, and incomplete days are red. Confirm days that only contain **not applicable** entries appear neutral (no success/danger tone).
 
 ## Streaks
 1. Navigate to the dashboard Habit list.
 2. For a habit with a current streak, mark the most recent day as **partial** and ensure the streak count resets to zero.
 3. Mark the same day as **complete** and confirm the streak count resumes (e.g., increases from the previous day).
-4. Repeat for multiple days to verify the streak only progresses when the status is "complete".
+4. Change the next day to **not applicable** and ensure the streak count does not break.
+5. Repeat for multiple days to verify the streak only progresses when the status is "complete" and skips days marked **not applicable**.
 
 ## Reminders
 1. Configure a habit with a reminder time that has already passed (e.g., morning reminder after 9 AM).
 2. Log the habit as **partial** for today.
    - Confirm the reminder toast reads “Keep going: … is partially complete.”
 3. Update the habit to **complete** and ensure no further reminder toasts appear.
-4. Create a different habit with no status logged and wait for the reminder window; confirm the toast uses the generic reminder message.
+4. Mark the habit as **not applicable** and confirm no reminder toasts are shown after the reminder window passes.
+5. Create a different habit with no status logged and wait for the reminder window; confirm the toast uses the generic reminder message.


### PR DESCRIPTION
## Summary
- exclude not applicable habit logs from daily progress widgets and statistics charts
- allow weekly calendar, streak evaluation, and reminders to ignore not applicable days
- extend manual QA steps to cover not applicable statuses across analytics and alerts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb9d7075b883279b59f6ff8aef703e