### PR TITLE
Fix habit log toggles and enforce log uniqueness

### DIFF
--- a/migrations/20250309_add_habit_log_uniqueness.sql
+++ b/migrations/20250309_add_habit_log_uniqueness.sql
@@ -1,0 +1,27 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'habit_logs'
+  ) THEN
+    -- Remove duplicate rows before adding the unique index
+    WITH ranked_logs AS (
+      SELECT
+        id,
+        ROW_NUMBER() OVER (
+          PARTITION BY habit_id, user_id, date
+          ORDER BY id DESC
+        ) AS rn
+      FROM habit_logs
+    )
+    DELETE FROM habit_logs
+    WHERE id IN (
+      SELECT id FROM ranked_logs WHERE rn > 1
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS habit_logs_habit_user_date_unique
+      ON habit_logs (habit_id, user_id, date);
+  END IF;
+END $$;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, timestamp, date, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, timestamp, date, pgEnum, uniqueIndex } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -65,7 +65,10 @@ export const habitLogs = pgTable("habit_logs", {
   userId: integer("user_id").notNull(),
   date: date("date").notNull(),
   status: habitStatusEnum("status").notNull().default("incomplete"),
-});
+}, (table) => ({
+  habitUserDateUnique: uniqueIndex("habit_logs_habit_user_date_unique")
+    .on(table.habitId, table.userId, table.date),
+}));
 
 export const insertHabitLogSchema = createInsertSchema(habitLogs).pick({
   habitId: true,


### PR DESCRIPTION
## Summary
- ensure habit log lookups always scope to the user and leverage an upsert when toggling status
- add a unique index (with cleanup) for one log per user, habit, and day
- expose the uniqueness in the shared schema so drizzle knows about it

## Testing
- npx tsc --noEmit --pretty false *(hangs locally, unable to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ffadbe55008327a06d30592914aadd